### PR TITLE
Support multiple cassette action icons

### DIFF
--- a/Data/cassettes (2).json
+++ b/Data/cassettes (2).json
@@ -1,1369 +1,1756 @@
 {
-	"cassettes": {
-		"Another One": {
-			"side_a": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"target_area": "slow_down",
-						"description": "Move to SLOW DOWN position"
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Avoid attacks to the back this turn",
-						"effect_name": "this_turn_target_attacks_behind_wont_work",
-						"target_area": "back"
-					}
-				],
-				"after_play": "burn",
-				"fuel_cost": 3
-			},
-			"side_b": {
-				"action_icon": "defence",
-				"actions": [
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "this",
-						"effect_name": "this_turn_attacks_from_front_wont_work",
-						"target_area": "front",
-						"value": 3
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 5
-			},
-			"image_a": "Images/CardsPremade/hound/another_one_a_side.png",
-			"image_b": "Images/CardsPremade/hound/another_one_b_side.png"
-		},
-		"Big Refill": {
-			"side_a": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Reduce all fuel costs by 1 permanently.",
-						"effect_name": "permanent_buff_fuel_cost_reduction",
-						"target_area": "all sides",
-						"value": 1
-					}
-				],
-				"after_play": "burn",
-				"fuel_cost": 1
-			},
-			"side_b": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Reduce the fuel cost of the next action by 3.",
-						"effect_name": "next_card_reduce_fuel",
-						"target_area": "all sides",
-						"value": 3
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 1
-			},
-			"image_a": "Images/CardsPremade/wife/big_refill_a_side.png",
-			"image_b": "Images/CardsPremade/wife/big_refill_b_side.png"
-		},
-		"Bites the Dust": {
-			"side_a": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "SLOW DOWN",
-						"target_area": "slow_down"
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Permanent +2 damage to attacks to the front.",
-						"effect_name": "permanent_buff_all_attacks",
-						"target_area": "all sides",
-						"value": 2
-					}
-				],
-				"after_play": "burn",
-				"fuel_cost": 2
-			},
-			"side_b": {
-				"action_icon": "attack_special",
-				"actions": [
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Attack in any direction. Add fuel spent so far as additional damage to this attack.",
-						"effect_name": "attack_deals_damage_plus_spent_fuel_as_bonus_damage_all_sides",
-						"target_area": "all sides",
-						"value": 1
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 4
-			},
-			"image_a": "Images/CardsPremade/hound/bites_the_dust_a_side.png",
-			"image_b": "Images/CardsPremade/hound/bites_the_dust_b_side.png"
-		},
-		"Burning Rubber": {
-			"side_a": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack to the back.",
-						"target_area": "back",
-						"value": 5
-					}
-				],
-				"after_play": "burn",
-				"fuel_cost": 3
-			},
-			"side_b": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "OVERTAKE",
-						"target_area": "overtake"
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Avoid next enemy attack.",
-						"effect_name": "next_attack_wont_work",
-						"target_area": "all sides"
-					}
-				],
-				"after_play": "burn",
-				"fuel_cost": 1
-			},
-			"image_a": "Images/CardsPremade/wife/burning_rubber_a_side.png",
-			"image_b": "Images/CardsPremade/wife/burning_rubber_b_side.png"
-		},
-		"Drafting": {
-			"side_a": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"animation_name": "move",
-						"description": "SLOW DOWN",
-						"target_area": "slow_down",
-						"value": ""
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": " If you begin your next turn on a SLOW DOWN position, all actions in that turn cost 1 fuel.",
-						"effect_name": "next_turn_reduce_all_action_cost",
-						"target_area": "behind",
-						"value": 1
-					}
-				],
-				"after_play": "burn",
-				"fuel_cost": 2
-			},
-			"side_b": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"animation_name": "move",
-						"description": "SLOW DOWN",
-						"target_area": "slow_down",
-						"value": ""
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"effect_name": "next_turn_first_action_cost_less",
-						"description": "If you begin your next turn in a SLOW DOWN position, reduce the next action's fuel cost by 1.",
-						"target_area": "all sides",
-						"value": 1
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 2
-			},
-			"image_a": "Images/CardsPremade/common cassettes/drafting_a_side.png",
-			"image_b": "Images/CardsPremade/common cassettes/drafting_b_side.png"
-		},
-		"Emergency Brake": {
-			"side_a": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "ram",
-						"description": "Attack to the back.",
-						"target_area": "back",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 3
-			},
-			"side_b": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Avoid an attack to the side.",
-						"effect_name": "this_turn_you_avoid_side_attacks",
-						"target_area": "side",
-						"value": ""
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 4
-			},
-			"image_a": "Images/CardsPremade/wife/emergency_brake_a_side.png",
-			"image_b": "Images/CardsPremade/wife/emergency_brake_b_side.png"
-		},
-		"EMP": {
-			"side_a": {
-				"action_icon": "attack_special",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack to the front.",
-						"target_area": "front",
-						"value": 2
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Disable enemy next action.",
-						"effect_name": "next_cassette_wont_work",
-						"target_area": "front",
-						"value": ""
-					}
-				],
-				"after_play": "burn",
-				"fuel_cost": 3
-			},
-			"side_b": {
-				"action_icon": "attack_special",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack to the back.",
-						"target_area": "back",
-						"value": 1
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Enemy cant overtake next turn.",
-						"effect_name": "next_turn_target_debuff_no_position_change",
-						"target_area": "back",
-						"value": ""
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 4
-			},
-			"image_a": "Images/CardsPremade/evans/emp_a_side.png",
-			"image_b": "Images/CardsPremade/evans/emp_b_side.png"
-		},
-		"Explosive Maneouver": {
-			"side_a": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "A devastating attack to the side and back.",
-						"target_area": "side and back",
-						"value": 12
-					}
-				],
-				"after_play": "burn",
-				"fuel_cost": 14
-			},
-			"side_b": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "OVERTAKE",
-						"target_area": "overtake",
-						"value": ""
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "+2 to the next attack.",
-						"effect_name": "buff_next_attack",
-						"target_area": "all sides",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 3
-			},
-			"image_a": "Images/CardsPremade/railgrinder/explosive_manoeuvre_a_side.png",
-			"image_b": "Images/CardsPremade/railgrinder/explosive_manoeuvre_b_side.png"
-		},
-		"Gimme Fire": {
-			"side_a": {
-				"action_icon": "attack_special",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack to the back.",
-						"target_area": "back",
-						"value": 2
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Enemy suffers +1 extra damage until they overtake.",
-						"effect_name": "damage_behind_and_line_up_every_cassette_this_turn",
-						"target_area": "side and back",
-						"value": 1
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 5
-			},
-			"side_b": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Next turn your actions cost less per point of damage received this turn.",
-						"effect_name": "next_turn_player_cassettes_cost_less_per_damage",
-						"target_area": "all sides"
-					}
-				],
-				"after_play": "burn",
-				"fuel_cost": 1
-			},
-			"image_a": "Images/CardsPremade/wife/gimme_fire_a_side.png",
-			"image_b": "Images/CardsPremade/wife/gimme_fire_b_side.png"
-		},
-		"Gimme Fuel": {
-			"side_a": {
-				"action_icon": "attack_special",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack to the front or side.",
-						"target_area": "side and front",
-						"value": 3
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Increase enemy fuel cost by 2 next turn.",
-						"effect_name": "next_turn_actions_cost_more_fuel",
-						"target_area": "all sides",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 7
-			},
-			"side_b": {
-				"action_icon": "attack_special",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack to the front or side.",
-						"target_area": "side and front",
-						"value": 2
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Increase the fuel cost of the next enemy action by 5.",
-						"effect_name": "next_card_target_costs_more_fuel",
-						"target_area": "all sides",
-						"value": 5
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 5
-			},
-			"image_a": "Images/CardsPremade/common cassettes/gimme_fuel_a_side.png",
-			"image_b": "Images/CardsPremade/common cassettes/gimme_fuel_b_side.png"
-		},
-		"Heavy Attack": {
-			"side_a": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Example description for side A",
-						"target_area": "side",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 2
-			},
-			"side_b": {
-				"action_icon": "defence",
-				"actions": [
-					{
-						"action_type": 1,
-						"animation_name": "",
-						"description": "Example description for side B",
-						"target_area": "overtake",
-						"value": ""
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 3
-			},
-			"image_a": null,
-			"image_b": null
-		},
-		"Hit me baby": {
-			"side_a": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "LINE UP.",
-						"target_area": "line_up"
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Damage reduction from all side attacks this turn.",
-						"effect_name": "this_turn_damage_reduction_side",
-						"target_area": "side",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 3
-			},
-			"side_b": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "SLOW DOWN.",
-						"target_area": "slow_down"
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Damage reduction from the attacks to the back this turn.",
-						"effect_name": "this_turn_damage_reduction_back",
-						"target_area": "back",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 1
-			},
-			"image_a": "Images/CardsPremade/common cassettes/hit_me_baby_a_side.png",
-			"image_b": "Images/CardsPremade/common cassettes/hit_me_baby_b_side.png"
-		},
-		"Hook, line and sinker": {
-			"side_a": {
-				"action_icon": "defence_special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "LINE UP.",
-						"target_area": "line_up",
-						"value": ""
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Damage reduction this turn.",
-						"effect_name": "acting_actor",
-						"target_area": "reduced_damage_taken_this_turn",
-						"value": 1
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": " Enemy can't move during their next action.",
-						"effect_name": "next_move_action_wont_work",
-						"target_area": "all sides",
-						"value": ""
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 3
-			},
-			"side_b": {
-				"action_icon": "defence_special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "OVERTAKE.",
-						"target_area": "overtake",
-						"value": ""
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Your next action will not change your position.",
-						"effect_name": "next_action_target_debuff_no_position_change",
-						"target_area": "all sides",
-						"value": ""
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 4
-			},
-			"image_a": "Images/CardsPremade/railgrinder/hook_line_and_sinker_a_side.png",
-			"image_b": "Images/CardsPremade/railgrinder/hook_line_and_sinker_b_side.png"
-		},
-		"Kickdown": {
-			"side_a": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "OVERTAKE.",
-						"target_area": "overtake"
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Increase your fuel cost 3 this turn.",
-						"effect_name": "debuff_this_turn_more_fuel_cost_you",
-						"target_area": "all sides",
-						"value": 3
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Increase your damage by 3 this turn.",
-						"effect_name": "+3_to_all_attacks",
-						"value": 3
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 3
-			},
-			"side_b": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "LINE UP.",
-						"target_area": "line_up"
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Stay on the position this turn.",
-						"effect_name": "this_turn_enemy_move_skills_dont_work",
-						"target_area": "all sides"
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 3
-			},
-			"image_a": "Images/CardsPremade/common cassettes/kickdown_a_side.png",
-			"image_b": "Images/CardsPremade/common cassettes/kickdown_b_side.png"
-		},
-		"Launcher Gallery": {
-			"side_a": {
-				"action_icon": "attack_special",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack to the side.",
-						"target_area": "side",
-						"value": 5
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "+2 damage to the next attack.",
-						"effect_name": "buff_next_attack",
-						"target_area": "all sides",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 7
-			},
-			"side_b": {
-				"action_icon": "attack_special",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack to the back.",
-						"target_area": "back",
-						"value": 4
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "+1 damage to the next attack.",
-						"effect_name": "buff_next_attack",
-						"target_area": "all sides",
-						"value": 1
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 6
-			},
-			"image_a": "Images/CardsPremade/railgrinder/launcher_gallery_a_side.png",
-			"image_b": "Images/CardsPremade/railgrinder/launcher_gallery_b_side.png"
-		},
-		"Letter D": {
-			"side_a": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "LINE UP.",
-						"target_area": "line_up",
-						"value": ""
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Avoid next enemy action against you.",
-						"effect_name": "next_attack_or_debuff_wont_work",
-						"target_area": "all sides",
-						"value": ""
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 3
-			},
-			"side_b": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"target_area": "overtake",
-						"value": ""
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"effect_name": "next_turn_avoid_all_actions",
-						"target_area": "all sides",
-						"value": ""
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"effect_name": "next_turn_debuff_player_less_damage",
-						"target_area": "all sides",
-						"value": 2
-					}
-				],
-				"after_play": "burn",
-				"description": "OVERTAKE. Avoid all enemy actions next turn and reduce your damage by 2. BURN.",
-				"fuel_cost": 1
-			},
-			"image_a": "Images/CardsPremade/common cassettes/letter_d_a_side.png",
-			"image_b": "Images/CardsPremade/common cassettes/letter_d_b_side.png"
-		},
-		"My name is Spike": {
-			"side_a": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"effect_name": "reflect_half_damage_at_the_end",
-						"target_area": "side and back"
-					}
-				],
-				"after_play": "discard",
-				"description": "At the end of this turn reflect half of the damage taken back to the enemy.",
-				"fuel_cost": 4
-			},
-			"side_b": {
-				"action_icon": "defence_special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "SLOW DOWN.",
-						"target_area": "slow_down"
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Damage reduction from the attacks to the back this turn.",
-						"effect_name": "this_turn_damage_reduction_front",
-						"target_area": "front",
-						"value": 1
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Reflect 1 damage from enemy next attack back to them.",
-						"effect_name": "reflect_damage_on_next_attack",
-						"target_area": "all sides",
-						"value": 1
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 3
-			},
-			"image_a": "Images/CardsPremade/boner/my_name_is_spike_a_side.png",
-			"image_b": "Images/CardsPremade/boner/my_name_is_spike_b_side.png"
-		},
-		"Nitro": {
-			"side_a": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "ram",
-						"description": "Attack to the back.",
-						"target_area": "back",
-						"value": 4
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 5
-			},
-			"side_b": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "Overtake.",
-						"target_area": "overtake"
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Enemy cant overtake next turn.",
-						"effect_name": "next_turn_target_debuff_no_position_change",
-						"target_area": "all sides",
-						"value": ""
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 3
-			},
-			"image_a": "Images/CardsPremade/wife/nitro_a_side.png",
-			"image_b": "Images/CardsPremade/wife/nitro_b_side.png"
-		},
-		"Offence is Defence": {
-			"side_a": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack to the side or back.",
-						"target_area": "side and back",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 5
-			},
-			"side_b": {
-				"action_icon": "defence",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "LINE UP.",
-						"target_area": "line_up"
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "LINE UP. Damage reduction from attacks to the side this turn.",
-						"effect_name": "this_turn_damage_reduction_side",
-						"target_area": "side",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 2
-			},
-			"image_a": "Images/CardsPremade/common cassettes/offence_is_defence_a_side.png",
-			"image_b": "Images/CardsPremade/common cassettes/offence_is_defence_b_side.png"
-		},
-		"Oil Spill": {
-			"side_a": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "OVERTAKE.",
-						"target_area": "overtake"
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "OVERTAKE. Enemy can't move during their next action.",
-						"effect_name": "next_move_action_wont_work",
-						"target_area": "all sides"
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 1
-			},
-			"side_b": {
-				"action_icon": "defence",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "OVERTAKE.",
-						"target_area": "overtake"
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Damage reduction this turn.",
-						"effect_name": "this_turn_damage_reduction",
-						"target_area": "all sides",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 3
-			},
-			"image_a": "Images/CardsPremade/wife/oil_spill_a_side.png",
-			"image_b": "Images/CardsPremade/wife/oil_spill_b_side.png"
-		},
-		"Perfectly Balanced": {
-			"side_a": {
-				"action_icon": "attack_defence",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "ram",
-						"description": "Attack to the side.",
-						"target_area": "side",
-						"value": 3
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Damage reduction.",
-						"effect_name": "this_turn_reduce_damage_from_sides",
-						"target_area": "side",
-						"value": 3
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 6
-			},
-			"side_b": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "LINE UP.",
-						"target_area": "line_up",
-						"value": ""
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Reduce fuel cost of the action by 1 when you LINE UP.",
-						"effect_name": "this_turn_reduce_fuel_cost_while_in_line_up",
-						"target_area": "all sides",
-						"value": 1
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 3
-			},
-			"image_a": "Images/CardsPremade/common cassettes/perfectly_balanced_a_side.png",
-			"image_b": "Images/CardsPremade/common cassettes/perfectly_balanced_b_side.png"
-		},
-		"Pew Pew": {
-			"side_a": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack to the side.",
-						"target_area": "side",
-						"value": 1
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 2
-			},
-			"side_b": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack to the front.",
-						"target_area": "front",
-						"value": 1
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 2
-			},
-			"image_a": "Images/CardsPremade/common cassettes/pew_pew_a_side.png",
-			"image_b": "Images/CardsPremade/common cassettes/pew_pew_b_side.png"
-		},
-		"Pit Maneouver": {
-			"side_a": {
-				"action_icon": "defence_special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "OVERTAKE.",
-						"target_area": "overtake"
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Enemy next action fuel cost is increased by 2.",
-						"effect_name": "next_enemy_cassette_cost_more",
-						"target_area": "all sides",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 6
-			},
-			"side_b": {
-				"action_icon": "attack_special",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "ram",
-						"description": "Attack to the side.",
-						"target_area": "side",
-						"value": 5
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Increase the fuel cost of the next enemy action by 2.",
-						"effect_name": "next_enemy_cassette_cost_more",
-						"target_area": "all sides",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 7
-			},
-			"image_a": "Images/CardsPremade/evans/pit_manoeuvre_a_side.png",
-			"image_b": "Images/CardsPremade/evans/pit_manoeuvre_b_side.png"
-		},
-		"Quick Attack": {
-			"side_a": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"target_area": "side",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"description": "Example description for side A",
-				"fuel_cost": 2
-			},
-			"side_b": {
-				"action_icon": "defence",
-				"actions": [
-					{
-						"action_type": 1,
-						"animation_name": "",
-						"target_area": "overtake",
-						"value": ""
-					}
-				],
-				"after_play": "discard",
-				"description": "Example description for side B",
-				"fuel_cost": 3
-			},
-			"image_a": null,
-			"image_b": null
-		},
-		"Rail the Tail": {
-			"side_a": {
-				"action_icon": "attack_special",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "ram",
-						"description": "Attack to the front.",
-						"target_area": "front",
-						"value": 4
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Attack to the front. Enemy next OVERTAKE becomes LINE UP or the next LINE UP is ignored.",
-						"effect_name": "less_movement_to_back",
-						"target_area": "all sides"
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 6
-			},
-			"side_b": {
-				"action_icon": "attack_special",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "ram",
-						"description": "Attack to the front.",
-						"target_area": "front",
-						"value": 1
-					},
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Fuel cost of enemy actions increased by 1 permanently.",
-						"effect_name": "until_end_all_cards_cost_more_fuel",
-						"target_area": "all sides",
-						"value": 1
-					}
-				],
-				"after_play": "burn",
-				"fuel_cost": 3
-			},
-			"image_a": "Images/CardsPremade/boner/rail_the_tail_a_side.png",
-			"image_b": "Images/CardsPremade/boner/rail_the_tail_b_side.png"
-		},
-		"Ram": {
-			"side_a": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "ram",
-						"description": "Attack to the front or side.",
-						"target_area": "side and front",
-						"value": 4
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 6
-			},
-			"side_b": {
-				"action_icon": "defence",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "LINE UP.",
-						"target_area": "line_up",
-						"value": ""
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Damage reduction this turn.",
-						"effect_name": "this_turn_damage_reduction_side",
-						"target_area": "side",
-						"value": 3
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 4
-			},
-			"image_a": "Images/CardsPremade/common cassettes/ram_a_side.png",
-			"image_b": "Images/CardsPremade/common cassettes/ram_b_side.png"
-		},
-		"Regular Attack": {
-			"side_a": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"target_area": "side",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"description": "Example description for side A",
-				"fuel_cost": 2
-			},
-			"side_b": {
-				"action_icon": "defence",
-				"actions": [
-					{
-						"action_type": 1,
-						"animation_name": "",
-						"target_area": "overtake",
-						"value": ""
-					}
-				],
-				"after_play": "discard",
-				"description": "Example description for side B",
-				"fuel_cost": 3
-			},
-			"image_a": null,
-			"image_b": null
-		},
-		"Road Rage": {
-			"side_a": {
-				"action_icon": "attack_defence",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "ram",
-						"description": "Attack in any direction.",
-						"target_area": "all sides",
-						"value": 4
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Damage reduction for next enemy cassette.",
-						"effect_name": "next_attack_damage_reduction_any_side",
-						"target_area": "all sides",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 8
-			},
-			"side_b": {
-				"action_icon": "attack_defence",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "ram",
-						"description": "Attack in any direction. ",
-						"target_area": "all sides",
-						"value": 2
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Damage reduction this turn.",
-						"effect_name": "next_attack_damage_reduction_any_side",
-						"target_area": "all sides",
-						"value": 4
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 8
-			},
-			"image_a": "Images/CardsPremade/common cassettes/road_rage_a_side.png",
-			"image_b": "Images/CardsPremade/common cassettes/road_rage_b_side.png"
-		},
-		"Roadslinger": {
-			"side_a": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "ram",
-						"description": "Attack to the front or back.",
-						"target_area": "back and front",
-						"value": 3
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 5
-			},
-			"side_b": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack to the side or back.",
-						"target_area": "side and back",
-						"value": 3
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 5
-			},
-			"image_a": "Images/CardsPremade/common cassettes/roadslinger_a_side.png",
-			"image_b": "Images/CardsPremade/common cassettes/roadslinger_b_side.png"
-		},
-		"Run to Live": {
-			"side_a": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 1,
-						"animation_name": "move",
-						"description": "OVERTAKE.",
-						"target_area": "overtake",
-						"value": ""
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Damage reduction from attacks to the front this turn.",
-						"effect_name": "this_turn_damage_reduction_back",
-						"target_area": "back",
-						"value": 3
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 4
-			},
-			"side_b": {
-				"action_icon": "defence",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "SLOW DOWN.",
-						"target_area": "slow_down",
-						"value": ""
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "SLOW DOWN. Damage reduction from attacks to the back this turn.",
-						"effect_name": "this_turn_damage_reduction_front",
-						"target_area": "front",
-						"value": 3
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 4
-			},
-			"image_a": "Images/CardsPremade/common cassettes/run_to_live_a_side.png",
-			"image_b": "Images/CardsPremade/common cassettes/run_to_live_b_side.png"
-		},
-		"Shoot em up": {
-			"side_a": {
-				"action_icon": "attack",
-				"actions": [
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack in any direction.",
-						"target_area": "all sides",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 5
-			},
-			"side_b": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "+1 damage to all attacks permanently.",
-						"effect_name": "permanent_buff_all_attacks",
-						"target_area": "all sides",
-						"value": 1
-					}
-				],
-				"after_play": "burn",
-				"fuel_cost": 3
-			},
-			"image_a": "Images/CardsPremade/common cassettes/shootem_up_a_side.png",
-			"image_b": "Images/CardsPremade/common cassettes/shootem_up_b_side.png"
-		},
-		"Whatever": {
-			"side_a": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Get a random buff: +2 damage, -2 fuel cost or +2 damage reduction.",
-						"effect_name": "random_buff_attack_fuel_defence",
-						"target_area": "all sides",
-						"value": 2
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 1
-			},
-			"side_b": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 2,
-						"affected_target": 0,
-						"description": "Give a random debuff: enemy damage reduced by 2, fuel cost increased by 2.",
-						"effect_name": "random_debuff_attack_fuel",
-						"target_area": "all sides",
-						"value": ""
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 1
-			},
-			"image_a": "Images/CardsPremade/wife/whatever_a_side.png",
-			"image_b": "Images/CardsPremade/wife/whatever_b_side.png"
-		},
-		"Honk Honk": {
-			"side_a": {
-				"action_icon": "special",
-				"actions": [
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "+1 damage to the next attack.",
-						"effect_name": "buff_next_attack",
-						"target_area": "all sides",
-						"value": 1
-					},
-					{
-						"action_type": 2,
-						"affected_target": 1,
-						"description": "Next attack hits all directions.",
-						"effect_name": "next_attack_all_direction",
-						"target_area": "all sides",
-						"value": ""
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 2
-			},
-			"side_b": {
-				"action_icon": "attack_special",
-				"actions": [
-					{
-						"action_type": 1,
-						"description": "OVERTAKE.",
-						"target_area": "overtake",
-						"value": ""
-					},
-					{
-						"action_type": 0,
-						"animation_name": "shoot",
-						"description": "Attack to the back.",
-						"target_area": "back",
-						"value": 1
-					}
-				],
-				"after_play": "discard",
-				"fuel_cost": 4
-			},
-			"image_a": "Images/CardsPremade/railgrinder/honk_honk_a_side.png",
-			"image_b": "Images/CardsPremade/railgrinder/honk_honk_b_side.png"
-		}
-	}
+    "cassettes": {
+        "Another One": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "target_area": "slow_down",
+                        "description": "Move to SLOW DOWN position"
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Avoid attacks to the back this turn",
+                        "effect_name": "this_turn_target_attacks_behind_wont_work",
+                        "target_area": "back"
+                    }
+                ],
+                "after_play": "burn",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 0
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "this",
+                        "effect_name": "this_turn_attacks_from_front_wont_work",
+                        "target_area": "front",
+                        "value": 3
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 5,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 3
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/hound/another_one_a_side.png",
+            "image_b": "Images/CardsPremade/hound/another_one_b_side.png"
+        },
+        "Big Refill": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Reduce all fuel costs by 1 permanently.",
+                        "effect_name": "permanent_buff_fuel_cost_reduction",
+                        "target_area": "all sides",
+                        "value": 1
+                    }
+                ],
+                "after_play": "burn",
+                "fuel_cost": 1,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 1
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Reduce the fuel cost of the next action by 3.",
+                        "effect_name": "next_card_reduce_fuel",
+                        "target_area": "all sides",
+                        "value": 3
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 1,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 3
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/wife/big_refill_a_side.png",
+            "image_b": "Images/CardsPremade/wife/big_refill_b_side.png"
+        },
+        "Bites the Dust": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "SLOW DOWN",
+                        "target_area": "slow_down"
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Permanent +2 damage to attacks to the front.",
+                        "effect_name": "permanent_buff_all_attacks",
+                        "target_area": "all sides",
+                        "value": 2
+                    }
+                ],
+                "after_play": "burn",
+                "fuel_cost": 2,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 2
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Attack in any direction. Add fuel spent so far as additional damage to this attack.",
+                        "effect_name": "attack_deals_damage_plus_spent_fuel_as_bonus_damage_all_sides",
+                        "target_area": "all sides",
+                        "value": 1
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 4,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 1
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/hound/bites_the_dust_a_side.png",
+            "image_b": "Images/CardsPremade/hound/bites_the_dust_b_side.png"
+        },
+        "Burning Rubber": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack to the back.",
+                        "target_area": "back",
+                        "value": 5
+                    }
+                ],
+                "after_play": "burn",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 5
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "OVERTAKE",
+                        "target_area": "overtake"
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Avoid next enemy attack.",
+                        "effect_name": "next_attack_wont_work",
+                        "target_area": "all sides"
+                    }
+                ],
+                "after_play": "burn",
+                "fuel_cost": 1,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 0
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/wife/burning_rubber_a_side.png",
+            "image_b": "Images/CardsPremade/wife/burning_rubber_b_side.png"
+        },
+        "Drafting": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "animation_name": "move",
+                        "description": "SLOW DOWN",
+                        "target_area": "slow_down",
+                        "value": ""
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": " If you begin your next turn on a SLOW DOWN position, all actions in that turn cost 1 fuel.",
+                        "effect_name": "next_turn_reduce_all_action_cost",
+                        "target_area": "behind",
+                        "value": 1
+                    }
+                ],
+                "after_play": "burn",
+                "fuel_cost": 2,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 1
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "animation_name": "move",
+                        "description": "SLOW DOWN",
+                        "target_area": "slow_down",
+                        "value": ""
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "effect_name": "next_turn_first_action_cost_less",
+                        "description": "If you begin your next turn in a SLOW DOWN position, reduce the next action's fuel cost by 1.",
+                        "target_area": "all sides",
+                        "value": 1
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 2,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 1
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/common cassettes/drafting_a_side.png",
+            "image_b": "Images/CardsPremade/common cassettes/drafting_b_side.png"
+        },
+        "Emergency Brake": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "ram",
+                        "description": "Attack to the back.",
+                        "target_area": "back",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 2
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Avoid an attack to the side.",
+                        "effect_name": "this_turn_you_avoid_side_attacks",
+                        "target_area": "side",
+                        "value": ""
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 4,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 0
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/wife/emergency_brake_a_side.png",
+            "image_b": "Images/CardsPremade/wife/emergency_brake_b_side.png"
+        },
+        "EMP": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack to the front.",
+                        "target_area": "front",
+                        "value": 2
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Disable enemy next action.",
+                        "effect_name": "next_cassette_wont_work",
+                        "target_area": "front",
+                        "value": ""
+                    }
+                ],
+                "after_play": "burn",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 2
+                    },
+                    {
+                        "icon": "defence",
+                        "value": 0
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack to the back.",
+                        "target_area": "back",
+                        "value": 1
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Enemy cant overtake next turn.",
+                        "effect_name": "next_turn_target_debuff_no_position_change",
+                        "target_area": "back",
+                        "value": ""
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 4,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 1
+                    },
+                    {
+                        "icon": "special",
+                        "value": 0
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/evans/emp_a_side.png",
+            "image_b": "Images/CardsPremade/evans/emp_b_side.png"
+        },
+        "Explosive Maneouver": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "A devastating attack to the side and back.",
+                        "target_area": "side and back",
+                        "value": 12
+                    }
+                ],
+                "after_play": "burn",
+                "fuel_cost": 14,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 12
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "OVERTAKE",
+                        "target_area": "overtake",
+                        "value": ""
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "+2 to the next attack.",
+                        "effect_name": "buff_next_attack",
+                        "target_area": "all sides",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 2
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/railgrinder/explosive_manoeuvre_a_side.png",
+            "image_b": "Images/CardsPremade/railgrinder/explosive_manoeuvre_b_side.png"
+        },
+        "Gimme Fire": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack to the back.",
+                        "target_area": "back",
+                        "value": 2
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Enemy suffers +1 extra damage until they overtake.",
+                        "effect_name": "damage_behind_and_line_up_every_cassette_this_turn",
+                        "target_area": "side and back",
+                        "value": 1
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 5,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 2
+                    },
+                    {
+                        "icon": "special",
+                        "value": 1
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Next turn your actions cost less per point of damage received this turn.",
+                        "effect_name": "next_turn_player_cassettes_cost_less_per_damage",
+                        "target_area": "all sides"
+                    }
+                ],
+                "after_play": "burn",
+                "fuel_cost": 1,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 0
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/wife/gimme_fire_a_side.png",
+            "image_b": "Images/CardsPremade/wife/gimme_fire_b_side.png"
+        },
+        "Gimme Fuel": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack to the front or side.",
+                        "target_area": "side and front",
+                        "value": 3
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Increase enemy fuel cost by 2 next turn.",
+                        "effect_name": "next_turn_actions_cost_more_fuel",
+                        "target_area": "all sides",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 7,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 3
+                    },
+                    {
+                        "icon": "special",
+                        "value": 2
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack to the front or side.",
+                        "target_area": "side and front",
+                        "value": 2
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Increase the fuel cost of the next enemy action by 5.",
+                        "effect_name": "next_card_target_costs_more_fuel",
+                        "target_area": "all sides",
+                        "value": 5
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 5,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 2
+                    },
+                    {
+                        "icon": "special",
+                        "value": 5
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/common cassettes/gimme_fuel_a_side.png",
+            "image_b": "Images/CardsPremade/common cassettes/gimme_fuel_b_side.png"
+        },
+        "Heavy Attack": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Example description for side A",
+                        "target_area": "side",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 2,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 2
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "animation_name": "",
+                        "description": "Example description for side B",
+                        "target_area": "overtake",
+                        "value": ""
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 3,
+                "action_icons": []
+            },
+            "image_a": null,
+            "image_b": null
+        },
+        "Hit me baby": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "LINE UP.",
+                        "target_area": "line_up"
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Damage reduction from all side attacks this turn.",
+                        "effect_name": "this_turn_damage_reduction_side",
+                        "target_area": "side",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 2
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "SLOW DOWN.",
+                        "target_area": "slow_down"
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Damage reduction from the attacks to the back this turn.",
+                        "effect_name": "this_turn_damage_reduction_back",
+                        "target_area": "back",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 1,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 2
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/common cassettes/hit_me_baby_a_side.png",
+            "image_b": "Images/CardsPremade/common cassettes/hit_me_baby_b_side.png"
+        },
+        "Hook, line and sinker": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "LINE UP.",
+                        "target_area": "line_up",
+                        "value": ""
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Damage reduction this turn.",
+                        "effect_name": "acting_actor",
+                        "target_area": "reduced_damage_taken_this_turn",
+                        "value": 1
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": " Enemy can't move during their next action.",
+                        "effect_name": "next_move_action_wont_work",
+                        "target_area": "all sides",
+                        "value": ""
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 1
+                    },
+                    {
+                        "icon": "defence",
+                        "value": 0
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "OVERTAKE.",
+                        "target_area": "overtake",
+                        "value": ""
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Your next action will not change your position.",
+                        "effect_name": "next_action_target_debuff_no_position_change",
+                        "target_area": "all sides",
+                        "value": ""
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 4,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 0
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/railgrinder/hook_line_and_sinker_a_side.png",
+            "image_b": "Images/CardsPremade/railgrinder/hook_line_and_sinker_b_side.png"
+        },
+        "Kickdown": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "OVERTAKE.",
+                        "target_area": "overtake"
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Increase your fuel cost 3 this turn.",
+                        "effect_name": "debuff_this_turn_more_fuel_cost_you",
+                        "target_area": "all sides",
+                        "value": 3
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Increase your damage by 3 this turn.",
+                        "effect_name": "+3_to_all_attacks",
+                        "value": 3
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 3
+                    },
+                    {
+                        "icon": "special",
+                        "value": 3
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "LINE UP.",
+                        "target_area": "line_up"
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Stay on the position this turn.",
+                        "effect_name": "this_turn_enemy_move_skills_dont_work",
+                        "target_area": "all sides"
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 0
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/common cassettes/kickdown_a_side.png",
+            "image_b": "Images/CardsPremade/common cassettes/kickdown_b_side.png"
+        },
+        "Launcher Gallery": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack to the side.",
+                        "target_area": "side",
+                        "value": 5
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "+2 damage to the next attack.",
+                        "effect_name": "buff_next_attack",
+                        "target_area": "all sides",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 7,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 5
+                    },
+                    {
+                        "icon": "special",
+                        "value": 2
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack to the back.",
+                        "target_area": "back",
+                        "value": 4
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "+1 damage to the next attack.",
+                        "effect_name": "buff_next_attack",
+                        "target_area": "all sides",
+                        "value": 1
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 6,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 4
+                    },
+                    {
+                        "icon": "special",
+                        "value": 1
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/railgrinder/launcher_gallery_a_side.png",
+            "image_b": "Images/CardsPremade/railgrinder/launcher_gallery_b_side.png"
+        },
+        "Letter D": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "LINE UP.",
+                        "target_area": "line_up",
+                        "value": ""
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Avoid next enemy action against you.",
+                        "effect_name": "next_attack_or_debuff_wont_work",
+                        "target_area": "all sides",
+                        "value": ""
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 0
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "target_area": "overtake",
+                        "value": ""
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "effect_name": "next_turn_avoid_all_actions",
+                        "target_area": "all sides",
+                        "value": ""
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "effect_name": "next_turn_debuff_player_less_damage",
+                        "target_area": "all sides",
+                        "value": 2
+                    }
+                ],
+                "after_play": "burn",
+                "description": "OVERTAKE. Avoid all enemy actions next turn and reduce your damage by 2. BURN.",
+                "fuel_cost": 1,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 0
+                    },
+                    {
+                        "icon": "special",
+                        "value": 2
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/common cassettes/letter_d_a_side.png",
+            "image_b": "Images/CardsPremade/common cassettes/letter_d_b_side.png"
+        },
+        "My name is Spike": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "effect_name": "reflect_half_damage_at_the_end",
+                        "target_area": "side and back"
+                    }
+                ],
+                "after_play": "discard",
+                "description": "At the end of this turn reflect half of the damage taken back to the enemy.",
+                "fuel_cost": 4,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 0
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "SLOW DOWN.",
+                        "target_area": "slow_down"
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Damage reduction from the attacks to the back this turn.",
+                        "effect_name": "this_turn_damage_reduction_front",
+                        "target_area": "front",
+                        "value": 1
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Reflect 1 damage from enemy next attack back to them.",
+                        "effect_name": "reflect_damage_on_next_attack",
+                        "target_area": "all sides",
+                        "value": 1
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 1
+                    },
+                    {
+                        "icon": "defence",
+                        "value": 1
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/boner/my_name_is_spike_a_side.png",
+            "image_b": "Images/CardsPremade/boner/my_name_is_spike_b_side.png"
+        },
+        "Nitro": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "ram",
+                        "description": "Attack to the back.",
+                        "target_area": "back",
+                        "value": 4
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 5,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 4
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "Overtake.",
+                        "target_area": "overtake"
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Enemy cant overtake next turn.",
+                        "effect_name": "next_turn_target_debuff_no_position_change",
+                        "target_area": "all sides",
+                        "value": ""
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 0
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/wife/nitro_a_side.png",
+            "image_b": "Images/CardsPremade/wife/nitro_b_side.png"
+        },
+        "Offence is Defence": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack to the side or back.",
+                        "target_area": "side and back",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 5,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 2
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "LINE UP.",
+                        "target_area": "line_up"
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "LINE UP. Damage reduction from attacks to the side this turn.",
+                        "effect_name": "this_turn_damage_reduction_side",
+                        "target_area": "side",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 2,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 2
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/common cassettes/offence_is_defence_a_side.png",
+            "image_b": "Images/CardsPremade/common cassettes/offence_is_defence_b_side.png"
+        },
+        "Oil Spill": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "OVERTAKE.",
+                        "target_area": "overtake"
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "OVERTAKE. Enemy can't move during their next action.",
+                        "effect_name": "next_move_action_wont_work",
+                        "target_area": "all sides"
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 1,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 0
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "OVERTAKE.",
+                        "target_area": "overtake"
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Damage reduction this turn.",
+                        "effect_name": "this_turn_damage_reduction",
+                        "target_area": "all sides",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 2
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/wife/oil_spill_a_side.png",
+            "image_b": "Images/CardsPremade/wife/oil_spill_b_side.png"
+        },
+        "Perfectly Balanced": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "ram",
+                        "description": "Attack to the side.",
+                        "target_area": "side",
+                        "value": 3
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Damage reduction.",
+                        "effect_name": "this_turn_reduce_damage_from_sides",
+                        "target_area": "side",
+                        "value": 3
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 6,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 3
+                    },
+                    {
+                        "icon": "special",
+                        "value": 3
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "LINE UP.",
+                        "target_area": "line_up",
+                        "value": ""
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Reduce fuel cost of the action by 1 when you LINE UP.",
+                        "effect_name": "this_turn_reduce_fuel_cost_while_in_line_up",
+                        "target_area": "all sides",
+                        "value": 1
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 1
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/common cassettes/perfectly_balanced_a_side.png",
+            "image_b": "Images/CardsPremade/common cassettes/perfectly_balanced_b_side.png"
+        },
+        "Pew Pew": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack to the side.",
+                        "target_area": "side",
+                        "value": 1
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 2,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 1
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack to the front.",
+                        "target_area": "front",
+                        "value": 1
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 2,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 1
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/common cassettes/pew_pew_a_side.png",
+            "image_b": "Images/CardsPremade/common cassettes/pew_pew_b_side.png"
+        },
+        "Pit Maneouver": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "OVERTAKE.",
+                        "target_area": "overtake"
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Enemy next action fuel cost is increased by 2.",
+                        "effect_name": "next_enemy_cassette_cost_more",
+                        "target_area": "all sides",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 6,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 2
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "ram",
+                        "description": "Attack to the side.",
+                        "target_area": "side",
+                        "value": 5
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Increase the fuel cost of the next enemy action by 2.",
+                        "effect_name": "next_enemy_cassette_cost_more",
+                        "target_area": "all sides",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 7,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 5
+                    },
+                    {
+                        "icon": "special",
+                        "value": 2
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/evans/pit_manoeuvre_a_side.png",
+            "image_b": "Images/CardsPremade/evans/pit_manoeuvre_b_side.png"
+        },
+        "Quick Attack": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "target_area": "side",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "description": "Example description for side A",
+                "fuel_cost": 2,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 2
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "animation_name": "",
+                        "target_area": "overtake",
+                        "value": ""
+                    }
+                ],
+                "after_play": "discard",
+                "description": "Example description for side B",
+                "fuel_cost": 3,
+                "action_icons": []
+            },
+            "image_a": null,
+            "image_b": null
+        },
+        "Rail the Tail": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "ram",
+                        "description": "Attack to the front.",
+                        "target_area": "front",
+                        "value": 4
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Attack to the front. Enemy next OVERTAKE becomes LINE UP or the next LINE UP is ignored.",
+                        "effect_name": "less_movement_to_back",
+                        "target_area": "all sides"
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 6,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 4
+                    },
+                    {
+                        "icon": "special",
+                        "value": 0
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "ram",
+                        "description": "Attack to the front.",
+                        "target_area": "front",
+                        "value": 1
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Fuel cost of enemy actions increased by 1 permanently.",
+                        "effect_name": "until_end_all_cards_cost_more_fuel",
+                        "target_area": "all sides",
+                        "value": 1
+                    }
+                ],
+                "after_play": "burn",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 1
+                    },
+                    {
+                        "icon": "special",
+                        "value": 1
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/boner/rail_the_tail_a_side.png",
+            "image_b": "Images/CardsPremade/boner/rail_the_tail_b_side.png"
+        },
+        "Ram": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "ram",
+                        "description": "Attack to the front or side.",
+                        "target_area": "side and front",
+                        "value": 4
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 6,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 4
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "LINE UP.",
+                        "target_area": "line_up",
+                        "value": ""
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Damage reduction this turn.",
+                        "effect_name": "this_turn_damage_reduction_side",
+                        "target_area": "side",
+                        "value": 3
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 4,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 3
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/common cassettes/ram_a_side.png",
+            "image_b": "Images/CardsPremade/common cassettes/ram_b_side.png"
+        },
+        "Regular Attack": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "target_area": "side",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "description": "Example description for side A",
+                "fuel_cost": 2,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 2
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "animation_name": "",
+                        "target_area": "overtake",
+                        "value": ""
+                    }
+                ],
+                "after_play": "discard",
+                "description": "Example description for side B",
+                "fuel_cost": 3,
+                "action_icons": []
+            },
+            "image_a": null,
+            "image_b": null
+        },
+        "Road Rage": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "ram",
+                        "description": "Attack in any direction.",
+                        "target_area": "all sides",
+                        "value": 4
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Damage reduction for next enemy cassette.",
+                        "effect_name": "next_attack_damage_reduction_any_side",
+                        "target_area": "all sides",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 8,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 4
+                    },
+                    {
+                        "icon": "defence",
+                        "value": 2
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "ram",
+                        "description": "Attack in any direction. ",
+                        "target_area": "all sides",
+                        "value": 2
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Damage reduction this turn.",
+                        "effect_name": "next_attack_damage_reduction_any_side",
+                        "target_area": "all sides",
+                        "value": 4
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 8,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 2
+                    },
+                    {
+                        "icon": "defence",
+                        "value": 4
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/common cassettes/road_rage_a_side.png",
+            "image_b": "Images/CardsPremade/common cassettes/road_rage_b_side.png"
+        },
+        "Roadslinger": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "ram",
+                        "description": "Attack to the front or back.",
+                        "target_area": "back and front",
+                        "value": 3
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 5,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 3
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack to the side or back.",
+                        "target_area": "side and back",
+                        "value": 3
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 5,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 3
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/common cassettes/roadslinger_a_side.png",
+            "image_b": "Images/CardsPremade/common cassettes/roadslinger_b_side.png"
+        },
+        "Run to Live": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "animation_name": "move",
+                        "description": "OVERTAKE.",
+                        "target_area": "overtake",
+                        "value": ""
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Damage reduction from attacks to the front this turn.",
+                        "effect_name": "this_turn_damage_reduction_back",
+                        "target_area": "back",
+                        "value": 3
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 4,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 3
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "SLOW DOWN.",
+                        "target_area": "slow_down",
+                        "value": ""
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "SLOW DOWN. Damage reduction from attacks to the back this turn.",
+                        "effect_name": "this_turn_damage_reduction_front",
+                        "target_area": "front",
+                        "value": 3
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 4,
+                "action_icons": [
+                    {
+                        "icon": "defence",
+                        "value": 3
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/common cassettes/run_to_live_a_side.png",
+            "image_b": "Images/CardsPremade/common cassettes/run_to_live_b_side.png"
+        },
+        "Shoot em up": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack in any direction.",
+                        "target_area": "all sides",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 5,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 2
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "+1 damage to all attacks permanently.",
+                        "effect_name": "permanent_buff_all_attacks",
+                        "target_area": "all sides",
+                        "value": 1
+                    }
+                ],
+                "after_play": "burn",
+                "fuel_cost": 3,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 1
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/common cassettes/shootem_up_a_side.png",
+            "image_b": "Images/CardsPremade/common cassettes/shootem_up_b_side.png"
+        },
+        "Whatever": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Get a random buff: +2 damage, -2 fuel cost or +2 damage reduction.",
+                        "effect_name": "random_buff_attack_fuel_defence",
+                        "target_area": "all sides",
+                        "value": 2
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 1,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 2
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 2,
+                        "affected_target": 0,
+                        "description": "Give a random debuff: enemy damage reduced by 2, fuel cost increased by 2.",
+                        "effect_name": "random_debuff_attack_fuel",
+                        "target_area": "all sides",
+                        "value": ""
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 1,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 0
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/wife/whatever_a_side.png",
+            "image_b": "Images/CardsPremade/wife/whatever_b_side.png"
+        },
+        "Honk Honk": {
+            "side_a": {
+                "actions": [
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "+1 damage to the next attack.",
+                        "effect_name": "buff_next_attack",
+                        "target_area": "all sides",
+                        "value": 1
+                    },
+                    {
+                        "action_type": 2,
+                        "affected_target": 1,
+                        "description": "Next attack hits all directions.",
+                        "effect_name": "next_attack_all_direction",
+                        "target_area": "all sides",
+                        "value": ""
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 2,
+                "action_icons": [
+                    {
+                        "icon": "special",
+                        "value": 1
+                    },
+                    {
+                        "icon": "special",
+                        "value": 0
+                    }
+                ]
+            },
+            "side_b": {
+                "actions": [
+                    {
+                        "action_type": 1,
+                        "description": "OVERTAKE.",
+                        "target_area": "overtake",
+                        "value": ""
+                    },
+                    {
+                        "action_type": 0,
+                        "animation_name": "shoot",
+                        "description": "Attack to the back.",
+                        "target_area": "back",
+                        "value": 1
+                    }
+                ],
+                "after_play": "discard",
+                "fuel_cost": 4,
+                "action_icons": [
+                    {
+                        "icon": "attack",
+                        "value": 1
+                    }
+                ]
+            },
+            "image_a": "Images/CardsPremade/railgrinder/honk_honk_a_side.png",
+            "image_b": "Images/CardsPremade/railgrinder/honk_honk_b_side.png"
+        }
+    }
 }

--- a/Features/FightScene/Cassette/cassette.gd
+++ b/Features/FightScene/Cassette/cassette.gd
@@ -65,17 +65,16 @@ func _on_area_2d_mouse_exited() -> void:
 
 
 func update_elements():
-	front_cassette_name_label.text = cassette_name
-	top_cassette_name_label.text = cassette_name
-	#SIDE A
-	side_a_fuel_label.text = str(side_a_data["fuel_cost"])
-	side_a_move_type_icon.texture = load("res://Images/action_icons/"+side_a_data["action_icon"]+".png")
-	set_icon_value(side_a_data, side_a_move_type_label)
-	if is_show_target_icon(side_a_data["actions"]):
-		side_a_attack_targets.visible = true
-		set_icon(get_icon_name(side_a_data["actions"]),side_a_attack_targets)
-	else:
-		side_a_attack_targets.visible = false
+        front_cassette_name_label.text = cassette_name
+        top_cassette_name_label.text = cassette_name
+        #SIDE A
+        side_a_fuel_label.text = str(side_a_data["fuel_cost"])
+        _display_action_icons(side_a_data, side_a_move_type_icon1, icon1_label, side_a_move_type_icon2, icon2_label)
+        if is_show_target_icon(side_a_data["actions"]):
+                side_a_attack_targets.visible = true
+                set_icon(get_icon_name(side_a_data["actions"]),side_a_attack_targets)
+        else:
+                side_a_attack_targets.visible = false
 	set_icon(side_a_data["after_play"],side_a_after_play)
 
 
@@ -125,7 +124,47 @@ func set_icon_value(action_data: Dictionary, label: Label) -> void:
 	var values_str = []
 	for cat in categories:
 		values_str.append(str(totals[cat]))
-	label.text = array_join(values_str, "|")
+        label.text = array_join(values_str, "|")
+
+# Display up to two action icons and their values
+func _get_filtered_icons(action_data: Dictionary) -> Array:
+        var icons = action_data.get("action_icons", [])
+        var result: Array = []
+        for info in icons:
+                var icon_name = str(info.get("icon", ""))
+                if icon_name in ["slow_down", "line_up", "overtake"]:
+                        continue
+                result.append(info)
+                if result.size() >= 2:
+                        break
+        return result
+
+func _get_value_text(info: Dictionary) -> String:
+        if not info.has("value"):
+                return ""
+        var val = info["value"]
+        if val == 0 or str(val) == "":
+                return ""
+        return str(val)
+
+func _display_action_icons(action_data: Dictionary, icon1: Sprite2D, label1: Label, icon2: Sprite2D, label2: Label) -> void:
+        var icons = _get_filtered_icons(action_data)
+        if icons.size() > 0:
+                var info = icons[0]
+                icon1.texture = load("res://Images/action_icons/%s.png" % info.get("icon", ""))
+                label1.text = _get_value_text(info)
+                icon1.visible = true
+        else:
+                icon1.visible = false
+                label1.text = ""
+        if icons.size() > 1:
+                var info2 = icons[1]
+                icon2.texture = load("res://Images/action_icons/%s.png" % info2.get("icon", ""))
+                label2.text = _get_value_text(info2)
+                icon2.visible = true
+        else:
+                icon2.visible = false
+                label2.text = ""
 
 
 func array_join(arr: Array, sep: String) -> String:

--- a/Features/FightScene/MiniCassette/mini_cassette.gd
+++ b/Features/FightScene/MiniCassette/mini_cassette.gd
@@ -15,49 +15,27 @@ var action_data = []
 var whose_cassette
 
 func set_cassette_data(current_icons):
-	#set_icons_data()
-	var action_label = current_icons.get_node("Action/Label")
-	if action_data[CASSETTE_SIDE_DATA.ACTION_ICON] == "attack" or action_data[CASSETTE_SIDE_DATA.ACTION_ICON] == "attack_special":
-		var attack = 0
-		for action in action_data[CASSETTE_SIDE_DATA.ACTIONS_LIST]:
-			if action[ACTION.MOVE_TYPE] == "attack":
-				attack = action[ACTION.VALUE]
-		action_label.text = str(attack)
-	elif action_data[CASSETTE_SIDE_DATA.ACTION_ICON] == "attack_defence":
-		var attack = 0
-		var defence = 0
-		for action in action_data[CASSETTE_SIDE_DATA.ACTIONS_LIST]:
-			if action[ACTION.MOVE_TYPE] == "attack":
-				attack = action[ACTION.VALUE]
-			if action[ACTION.MOVE_TYPE] == "special":
-				defence =action[ACTION.VALUE]
-		action_label.text = str(attack)+"|"+str(defence)
-	elif action_data[CASSETTE_SIDE_DATA.ACTION_ICON] == "defence":
-		var defence = 0
-		for action in action_data[CASSETTE_SIDE_DATA.ACTIONS_LIST]:
-			if action[ACTION.MOVE_TYPE] == "special":
-				defence =action[ACTION.VALUE]
-		action_label.text = str(defence)
-	elif action_data[CASSETTE_SIDE_DATA.ACTION_ICON] == "defence_special":
-		var special = 0
-		for action in action_data[CASSETTE_SIDE_DATA.ACTIONS_LIST]:
-			if action[ACTION.MOVE_TYPE] == "special":
-				special = action[ACTION.VALUE]
-		if special == "":
-			action_label.text = str(special)
-	elif action_data[CASSETTE_SIDE_DATA.ACTION_ICON] == "special":
-		var special = 0
-		for action in action_data[CASSETTE_SIDE_DATA.ACTIONS_LIST]:
-			if action[ACTION.MOVE_TYPE] == "special":
-				special = action[ACTION.VALUE]
-		action_label.text = str(special)
-	else:
-		action_label = ""
-	maneouver_description.text = action_data[CASSETTE_SIDE_DATA.DESCRIPTION]
-	current_icons.get_node("Action").texture = load("res://Images/action_icons/"+action_data[CASSETTE_SIDE_DATA.ACTION_ICON]+".png")
-	after_turn_icon.texture = load("res://Images/action_icons/"+action_data[CASSETTE_SIDE_DATA.AFTER_PLAY]+".png")
-	var fuel_label =  current_icons.get_node("Fuel/Label")
-	fuel_label.text = str(action_data[CASSETTE_SIDE_DATA.FUEL_COST])
+        var action_label = current_icons.get_node("Action/Label")
+        var icons = action_data.get("action_icons", [])
+        var shown = false
+        for info in icons:
+                var icon_name = str(info.get("icon", ""))
+                if icon_name in ["slow_down", "line_up", "overtake"]:
+                        continue
+                current_icons.get_node("Action").texture = load("res://Images/action_icons/%s.png" % icon_name)
+                var value = info.get("value", "")
+                if value == 0 or str(value) == "":
+                        action_label.text = ""
+                else:
+                        action_label.text = str(value)
+                shown = true
+                break
+        if not shown:
+                action_label.text = ""
+        after_turn_icon.texture = load("res://Images/action_icons/%s.png" % action_data[CASSETTE_SIDE_DATA.AFTER_PLAY])
+        var fuel_label = current_icons.get_node("Fuel/Label")
+        fuel_label.text = str(action_data[CASSETTE_SIDE_DATA.FUEL_COST])
+        maneouver_description.text = action_data[CASSETTE_SIDE_DATA.DESCRIPTION]
 	
 #func set_icons_visibility():
 	#if whose_cassette == GlobalEnums.PLAYER:

--- a/Scripts/cassette_preview.gd
+++ b/Scripts/cassette_preview.gd
@@ -38,16 +38,14 @@ func highlight_cassette(should_highlight):
 		tween_hover.tween_property($CassetteSprites, "scale", REGULAR_CASSETTE_SIZE, 0.1)
 
 func update_elements():
-	$CassetteSprites/Front/CassetteName.text = cassette_name
-	$CassetteSprites/Top/CassetteName.text = cassette_name
-	$CassetteSprites/SideA/Fuel/Label.text = str(cassette_side_a[CASSETTE_SIDE_DATA.FUEL_COST])
-	$CassetteSprites/SideA/Description.text = cassette_side_a[CASSETTE_SIDE_DATA.DESCRIPTION]
-	$CassetteSprites/SideB/Fuel/Label.text = str(cassette_side_b[CASSETTE_SIDE_DATA.FUEL_COST])
-	$CassetteSprites/SideB/Description.text = cassette_side_b[CASSETTE_SIDE_DATA.DESCRIPTION]
-	$CassetteSprites/SideA/Icon.texture = load("res://Images/action_icons/"+cassette_side_a[CASSETTE_SIDE_DATA.ACTION_ICON]+".png")
-	set_icon_value(cassette_side_a, $CassetteSprites/SideA/Icon/Label)
-	$CassetteSprites/SideB/Icon.texture = load("res://Images/action_icons/"+cassette_side_b[CASSETTE_SIDE_DATA.ACTION_ICON]+".png")
-	set_icon_value(cassette_side_b, $CassetteSprites/SideB/Icon/Label)
+        $CassetteSprites/Front/CassetteName.text = cassette_name
+        $CassetteSprites/Top/CassetteName.text = cassette_name
+        $CassetteSprites/SideA/Fuel/Label.text = str(cassette_side_a[CASSETTE_SIDE_DATA.FUEL_COST])
+        $CassetteSprites/SideA/Description.text = cassette_side_a[CASSETTE_SIDE_DATA.DESCRIPTION]
+        $CassetteSprites/SideB/Fuel/Label.text = str(cassette_side_b[CASSETTE_SIDE_DATA.FUEL_COST])
+        $CassetteSprites/SideB/Description.text = cassette_side_b[CASSETTE_SIDE_DATA.DESCRIPTION]
+        _display_icon(cassette_side_a, $CassetteSprites/SideA/Icon, $CassetteSprites/SideA/Icon/Label)
+        _display_icon(cassette_side_b, $CassetteSprites/SideB/Icon, $CassetteSprites/SideB/Icon/Label)
 
 func get_current_side_fuel():
 	if current_side == "A":
@@ -61,55 +59,20 @@ func set_name_labels():
 	$CassetteSprites/Front/CassetteName.text = cassette_name
 	$CassetteSprites/Top/CassetteName.text = cassette_name
 
-func set_icon_value(cassette_data, label):
-	if cassette_data[CASSETTE_SIDE_DATA.ACTION_ICON] == "attack":
-		var attack = 0
-		for action in cassette_data[CASSETTE_SIDE_DATA.ACTIONS_LIST]:
-			if action[ACTION.MOVE_TYPE] == "attack":
-				attack = action[ACTION.VALUE]
-		label.text = str(attack)
-	elif cassette_data[CASSETTE_SIDE_DATA.ACTION_ICON] == "attack_special":
-		var attack = 0
-		var special = 0
-		for action in cassette_data[CASSETTE_SIDE_DATA.ACTIONS_LIST]:
-			if action[ACTION.MOVE_TYPE] == "attack":
-				attack = action[ACTION.VALUE]
-		for action in cassette_data[CASSETTE_SIDE_DATA.ACTIONS_LIST]:
-			if action[ACTION.MOVE_TYPE] == "special":
-				special = action[ACTION.VALUE]
-		if attack == 0:
-			label.text = str(special)
-		if special == 0:
-			label.text = str(attack)
-	elif cassette_data[CASSETTE_SIDE_DATA.ACTION_ICON] == "attack_defence":
-		var attack = 0
-		var defence = 0
-		for action in cassette_data[CASSETTE_SIDE_DATA.ACTIONS_LIST]:
-			if action[ACTION.MOVE_TYPE] == "attack":
-				attack = action[ACTION.VALUE]
-			if action[ACTION.MOVE_TYPE] == "special":
-				defence += action[ACTION.VALUE]
-		label.text = str(attack)+"|"+str(defence)
-	elif cassette_data[CASSETTE_SIDE_DATA.ACTION_ICON] == "defence":
-		var defence = 0
-		for action in cassette_data[CASSETTE_SIDE_DATA.ACTIONS_LIST]:
-			if action[ACTION.MOVE_TYPE] == "special":
-				defence =action[ACTION.VALUE]
-		label.text = str(defence)
-	elif cassette_data[CASSETTE_SIDE_DATA.ACTION_ICON] == "defence_special":
-		var special = 0
-		for action in cassette_data[CASSETTE_SIDE_DATA.ACTIONS_LIST]:
-			if action[ACTION.MOVE_TYPE] == "special":
-				special = action[ACTION.VALUE]
-		label.text = str(special)
-	elif cassette_data[CASSETTE_SIDE_DATA.ACTION_ICON] == "special":
-		var special = 0
-		for action in cassette_data[CASSETTE_SIDE_DATA.ACTIONS_LIST]:
-			if action[ACTION.MOVE_TYPE] == "special":
-				special = action[ACTION.VALUE]
-		label.text = str(special)
-	else:
-		label = ""
+func _display_icon(cassette_data, icon_node, label_node):
+        var icons = cassette_data.get("action_icons", [])
+        for info in icons:
+                var icon_name = str(info.get("icon", ""))
+                if icon_name in ["slow_down", "line_up", "overtake"]:
+                        continue
+                icon_node.texture = load("res://Images/action_icons/%s.png" % icon_name)
+                var value = info.get("value", "")
+                if value == 0 or str(value) == "":
+                        label_node.text = ""
+                else:
+                        label_node.text = str(value)
+                return
+        label_node.text = ""
 	
 
 func switch_preview_sides(current_preview_side):


### PR DESCRIPTION
## Summary
- update `cassettes (2).json` to filter out slow_down/line_up/overtake icons
- skip unsupported icons and hide zero values in cassette scripts

## Testing
- `python -m json.tool 'Data/cassettes (2).json'`


------
https://chatgpt.com/codex/tasks/task_e_6846d581390c8320b92ceb141033e633