### PR TITLE
Align enemy cassette scene with player cassette

### DIFF
--- a/Features/FightScene/EnemyCassette/enemy_cassette.tscn
+++ b/Features/FightScene/EnemyCassette/enemy_cassette.tscn
@@ -1,36 +1,29 @@
-[gd_scene load_steps=26 format=3 uid="uid://dw0n05mcits0x"]
+[gd_scene load_steps=26 format=3 uid="uid://bv0hep3nj7s5i"]
 
-[ext_resource type="Script" uid="uid://c0g32ne6d7lqq" path="res://Features/FightScene/Cassette/cassette.gd" id="1_vftii"]
-[ext_resource type="Texture2D" uid="uid://bqvadmvpaliuo" path="res://Images/cassette/cassette front/text box.png" id="4_prap6"]
-[ext_resource type="Texture2D" uid="uid://sv0sakk6sx8w" path="res://Images/cassette/cassette front/fuel.png" id="5_6emyt"]
-[ext_resource type="FontFile" uid="uid://dtn7qee5h51x5" path="res://Font/atwriter.ttf" id="6_j52hp"]
-[ext_resource type="Texture2D" uid="uid://x3fcdafib402" path="res://Images/cassette/cassette front/attack.png" id="7_4djja"]
-[ext_resource type="Texture2D" uid="uid://bd6fqsna3edu2" path="res://Images/cassette/cassette top/1 case top v2.png" id="7_i4oxk"]
-[ext_resource type="Texture2D" uid="uid://dat1u8t86k05y" path="res://Images/cassette/cassette top/2 top label.png" id="8_q7mcy"]
-[ext_resource type="Texture2D" uid="uid://c0hl036w3juhg" path="res://Images/action_icons/attack_all_sides.png" id="8_y3dw0"]
-[ext_resource type="Texture2D" uid="uid://c64671rylr8jv" path="res://Images/action_icons/discard.png" id="9_goh0x"]
-[ext_resource type="Texture2D" uid="uid://dbu4otahu4w27" path="res://Images/action_icons/burn icon.png" id="10_5jphp"]
-[ext_resource type="Texture2D" uid="uid://cvtclg7lpuej1" path="res://Images/cassette/cassette front/1 label.png" id="11_dnua6"]
-[ext_resource type="Texture2D" uid="uid://bri5abvba2nda" path="res://Images/cassette/cassette front/2 case c v2.png" id="12_c1rf7"]
-[ext_resource type="Texture2D" uid="uid://1jexkvbes2ne" path="res://Images/cassette/cassette front/3 gears v2.png" id="13_1vaqd"]
-[ext_resource type="FontFile" uid="uid://bf27d738cuys7" path="res://Font/RockSalt-Regular.ttf" id="14_w2qko"]
-[ext_resource type="Texture2D" uid="uid://bc66jvhfkucid" path="res://Images/cassette/cassette front/A side.png" id="15_ck6wr"]
-[ext_resource type="Texture2D" uid="uid://brmt4wph5umix" path="res://Images/cassette/cassette front/B side.png" id="16_eplrv"]
-[ext_resource type="Texture2D" uid="uid://bxu4re1jrhh2j" path="res://Images/cassette/cassette side/case side v2.png" id="17_xsyxj"]
-[ext_resource type="Texture2D" uid="uid://vc3k7cuctp21" path="res://Images/action_icons/attack.png" id="18_74lal"]
-[ext_resource type="Texture2D" uid="uid://dnbv1ykq1xen0" path="res://Images/action_icons/defence.png" id="19_u2054"]
-[ext_resource type="Texture2D" uid="uid://c64671rylr8jv" path="res://Images/action_icons/discard.png" id="20_ocsrf"]
-[ext_resource type="Texture2D" uid="uid://bx1gp3qdyw08t" path="res://Images/CardsPremade/boner/my_name_is_spike_a_side.png" id="21_k86ah"]
+[ext_resource type="Script" uid="uid://c0g32ne6d7lqq" path="res://Features/FightScene/Cassette/cassette.gd" id="1_sndn0"]
+[ext_resource type="Texture2D" uid="uid://cvtclg7lpuej1" path="res://Images/cassette/cassette front/1 label.png" id="2_o2424"]
+[ext_resource type="Texture2D" uid="uid://bri5abvba2nda" path="res://Images/cassette/cassette front/2 case c v2.png" id="3_fk2f7"]
+[ext_resource type="Texture2D" uid="uid://1jexkvbes2ne" path="res://Images/cassette/cassette front/3 gears v2.png" id="4_dm7ik"]
+[ext_resource type="FontFile" uid="uid://bf27d738cuys7" path="res://Font/RockSalt-Regular.ttf" id="5_ir5hr"]
+[ext_resource type="Texture2D" uid="uid://bc66jvhfkucid" path="res://Images/cassette/cassette front/A side.png" id="6_mmpey"]
+[ext_resource type="Texture2D" uid="uid://bxu4re1jrhh2j" path="res://Images/cassette/cassette side/case side v2.png" id="7_xm1pe"]
+[ext_resource type="Texture2D" uid="uid://bd6fqsna3edu2" path="res://Images/cassette/cassette top/1 case top v2.png" id="8_6ahv7"]
+[ext_resource type="Texture2D" uid="uid://dat1u8t86k05y" path="res://Images/cassette/cassette top/2 top label.png" id="9_17ljl"]
+[ext_resource type="Texture2D" uid="uid://sv0sakk6sx8w" path="res://Images/cassette/cassette front/fuel.png" id="10_2suj0"]
+[ext_resource type="FontFile" uid="uid://dtn7qee5h51x5" path="res://Font/atwriter.ttf" id="11_i25h6"]
+[ext_resource type="Texture2D" uid="uid://vc3k7cuctp21" path="res://Images/action_icons/attack.png" id="12_74lal"]
+[ext_resource type="Texture2D" uid="uid://dnbv1ykq1xen0" path="res://Images/action_icons/defence.png" id="13_u2054"]
+[ext_resource type="Texture2D" uid="uid://c64671rylr8jv" path="res://Images/action_icons/discard.png" id="14_ocsrf"]
+[ext_resource type="Texture2D" uid="uid://bx1gp3qdyw08t" path="res://Images/CardsPremade/boner/my_name_is_spike_a_side.png" id="15_k86ah"]
+[ext_resource type="Texture2D" uid="uid://d2jiuwd0gc6pj" path="res://Images/cassette/cassette front/flip cassette tooltip.png" id="16_bm5ih"]
 
-[sub_resource type="FontVariation" id="FontVariation_xan1t"]
-base_font = ExtResource("6_j52hp")
+[sub_resource type="FontVariation" id="FontVariation_avwf4"]
+base_font = ExtResource("5_ir5hr")
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_0x1d7"]
-size = Vector2(442, 40)
-
-[sub_resource type="Animation" id="Animation_7u67c"]
-resource_name = "CassetteVanish"
+[sub_resource type="Animation" id="Animation_5rfmn"]
+resource_name = "Cassette_vanish"
 length = 0.3
+step = 0.001
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -42,6 +35,76 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
 "values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_6jk51"]
+resource_name = "Hover_over"
+length = 0.1
+step = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Sprites:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(0, 0), Vector2(0, -320)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Sprites/SideA:visible")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0.09, 0.1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [false, true]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Sprites:scale")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(1, 1), Vector2(1.5, 1.5)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("FlipTooltip:position")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(-390, -95), Vector2(-596, -485)]
+}
+tracks/4/type = "method"
+tracks/4/imported = false
+tracks/4/enabled = false
+tracks/4/path = NodePath(".")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0.001, 0.1),
+"transitions": PackedFloat32Array(1, 1),
+"values": [{
+"args": [],
+"method": &"print_start_animation"
+}, {
+"args": [],
+"method": &"print_end_animation"
+}]
 }
 
 [sub_resource type="Animation" id="Animation_bdam2"]
@@ -68,31 +131,127 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(1, 1)]
+"values": [Vector2(1, 0)]
 }
 tracks/2/type = "value"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath("Area2D/CollisionShape2D:shape:size")
+tracks/2/path = NodePath("Sprites/Front:scale")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(442, 40)]
+"values": [Vector2(1, 1)]
 }
 tracks/3/type = "value"
 tracks/3/imported = false
 tracks/3/enabled = true
-tracks/3/path = NodePath("Sprites:modulate")
+tracks/3/path = NodePath("Sprites/Front:position")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
+"values": [Vector2(0, 0)]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("Sprites/SideA:visible")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [false]
+}
+tracks/5/type = "value"
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/path = NodePath("Sprites:scale")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(1, 1)]
+}
+tracks/6/type = "value"
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/path = NodePath("FlipTooltip:position")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(-390, -95)]
+}
+tracks/7/type = "value"
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/path = NodePath("FlipTooltip:visible")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/8/type = "value"
+tracks/8/imported = false
+tracks/8/enabled = true
+tracks/8/path = NodePath("Sprites:position")
+tracks/8/interp = 1
+tracks/8/loop_wrap = true
+tracks/8/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(0, 0)]
+}
+tracks/9/type = "value"
+tracks/9/imported = false
+tracks/9/enabled = true
+tracks/9/path = NodePath("Sprites:modulate")
+tracks/9/interp = 1
+tracks/9/loop_wrap = true
+tracks/9/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
 "values": [Color(1, 1, 1, 1)]
+}
+tracks/10/type = "value"
+tracks/10/imported = false
+tracks/10/enabled = true
+tracks/10/path = NodePath("Area2D/CollisionShape2D:shape:size")
+tracks/10/interp = 1
+tracks/10/loop_wrap = true
+tracks/10/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(442, 563.333)]
+}
+tracks/11/type = "value"
+tracks/11/imported = false
+tracks/11/enabled = true
+tracks/11/path = NodePath("Area2D/CollisionShape2D:position")
+tracks/11/interp = 1
+tracks/11/loop_wrap = true
+tracks/11/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(0, -640)]
 }
 
 [sub_resource type="Animation" id="Animation_1rwco"]
@@ -126,20 +285,133 @@ tracks/1/keys = {
 tracks/2/type = "value"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath("Area2D/CollisionShape2D:shape:size")
+tracks/2/path = NodePath("Sprites/Front:scale")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
 "times": PackedFloat32Array(0, 0.2),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
-"values": [Vector2(442, 40), Vector2(442, 280)]
+"values": [Vector2(1, 1e-05), Vector2(1, 1)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("Sprites/Front:position")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(0, 20), Vector2(0, 0)]
+}
+tracks/4/type = "method"
+tracks/4/imported = false
+tracks/4/enabled = false
+tracks/4/path = NodePath(".")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0.001, 0.2),
+"transitions": PackedFloat32Array(1, 1),
+"values": [{
+"args": [],
+"method": &"print_start_animation"
+}, {
+"args": [],
+"method": &"print_end_animation"
+}]
+}
+tracks/5/type = "value"
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/path = NodePath("Area2D/CollisionShape2D:shape:size")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/keys = {
+"times": PackedFloat32Array(0, 0.2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(442, 353.333), Vector2(442, 563.333)]
+}
+tracks/6/type = "value"
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/path = NodePath("Area2D/CollisionShape2D:position")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/keys = {
+"times": PackedFloat32Array(0, 0.2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(1, 0), Vector2(0, -640)]
 }
 
 [sub_resource type="Animation" id="Animation_75skt"]
 resource_name = "SwitchToOtherSide"
 length = 0.3
 step = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Sprites/Front:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.149, 0.15, 0.3),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 0,
+"values": [Vector2(0, 0), Vector2(20, 0), Vector2(-20, 0), Vector2(0, 0)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Sprites/Front:scale")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.149, 0.15, 0.3),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 0,
+"values": [Vector2(1, 1), Vector2(0, 1), Vector2(0, 1), Vector2(1, 1)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Sprites/Side:position")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.15, 0.3),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(-223, 0), Vector2(0, 3), Vector2(223, 3)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("Sprites/Side:scale")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.15, 0.3),
+"transitions": PackedFloat32Array(0.840896, 1, 1.51572),
+"update": 0,
+"values": [Vector2(0, 1), Vector2(1, 1), Vector2(0, 1)]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("Sprites/Front/Gears:scale")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0, 0.149, 0.15),
+"transitions": PackedFloat32Array(1, 1, 1e-05),
+"update": 0,
+"values": [Vector2(1, 1), Vector2(1, 1), Vector2(-1, 1)]
+}
 
 [sub_resource type="Animation" id="Animation_sagpx"]
 resource_name = "SwitchToTopSide"
@@ -172,148 +444,149 @@ tracks/1/keys = {
 tracks/2/type = "value"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath("Area2D/CollisionShape2D:shape:size")
+tracks/2/path = NodePath("Sprites/Front:position")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
 "times": PackedFloat32Array(0, 0.2),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
-"values": [Vector2(442, 277), Vector2(442, 43)]
+"values": [Vector2(0, 0), Vector2(0, 20)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("Sprites/Front:scale")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(1, 1), Vector2(1, 0)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_o46m7"]
 _data = {
-&"CassetteVanish": SubResource("Animation_7u67c"),
+&"Cassette_vanish": SubResource("Animation_5rfmn"),
+&"Hover_over": SubResource("Animation_6jk51"),
 &"RESET": SubResource("Animation_bdam2"),
 &"SwitchToFront": SubResource("Animation_1rwco"),
 &"SwitchToOtherSide": SubResource("Animation_75skt"),
 &"SwitchToTopSide": SubResource("Animation_sagpx")
 }
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_axh4p"]
+size = Vector2(442, 563.333)
+
 [node name="Cassette" type="Node2D"]
-light_mask = 524288
-visibility_layer = 524288
-script = ExtResource("1_vftii")
+script = ExtResource("1_sndn0")
 
 [node name="Sprites" type="Node2D" parent="."]
-scale = Vector2(0.75, 0.75)
-
-[node name="Top" type="Node2D" parent="Sprites"]
-
-[node name="Sprite2D" type="Sprite2D" parent="Sprites/Top"]
-texture = ExtResource("7_i4oxk")
-
-[node name="Sprite2D2" type="Sprite2D" parent="Sprites/Top"]
-texture = ExtResource("8_q7mcy")
-
-[node name="CassetteName" type="Label" parent="Sprites/Top"]
-visible = false
 light_mask = 524288
 visibility_layer = 524288
-offset_left = -75.0
-offset_top = -77.5
-offset_right = 65.0
-offset_bottom = 93.5
+
+[node name="Front" type="Node2D" parent="Sprites"]
+
+[node name="Label" type="Sprite2D" parent="Sprites/Front"]
+texture = ExtResource("2_o2424")
+
+[node name="Frame" type="Sprite2D" parent="Sprites/Front"]
+texture = ExtResource("3_fk2f7")
+
+[node name="Gears" type="Sprite2D" parent="Sprites/Front"]
+texture = ExtResource("4_dm7ik")
+
+[node name="CassetteName" type="Label" parent="Sprites/Front"]
+offset_left = -166.0
+offset_top = -125.0
+offset_right = 119.0
+offset_bottom = -52.9999
 theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_outline_color = Color(1, 1, 1, 1)
-theme_override_constants/outline_size = 20
-theme_override_fonts/font = ExtResource("6_j52hp")
-theme_override_font_sizes/font_size = 140
-text = "5"
+theme_override_fonts/font = ExtResource("5_ir5hr")
+theme_override_font_sizes/font_size = 26
+text = "SUPA DORIFTO"
 horizontal_alignment = 1
 vertical_alignment = 1
 metadata/_edit_use_anchors_ = true
 
+[node name="ASideLogo" type="Sprite2D" parent="Sprites/Front"]
+light_mask = 524288
+visibility_layer = 524288
+position = Vector2(161, -90)
+scale = Vector2(0.390625, 0.359375)
+texture = ExtResource("6_mmpey")
+
+[node name="Side" type="Node2D" parent="Sprites"]
+position = Vector2(-223, 0)
+scale = Vector2(1e-05, 1)
+
+[node name="Frame" type="Sprite2D" parent="Sprites/Side"]
+texture = ExtResource("7_xm1pe")
+
+[node name="Top" type="Node2D" parent="Sprites"]
+scale = Vector2(1, 1e-05)
+
+[node name="Frame" type="Sprite2D" parent="Sprites/Top"]
+texture = ExtResource("8_6ahv7")
+
+[node name="Label" type="Sprite2D" parent="Sprites/Top"]
+texture = ExtResource("9_17ljl")
+
+[node name="CassetteName" type="Label" parent="Sprites/Top"]
+offset_left = -92.0
+offset_top = -20.0
+offset_right = 91.0
+offset_bottom = 19.0
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 2
+theme_override_fonts/font = SubResource("FontVariation_avwf4")
+theme_override_font_sizes/font_size = 16
+text = "SUPA DORIFTO"
+horizontal_alignment = 1
+vertical_alignment = 1
+
 [node name="SideA" type="Node2D" parent="Sprites"]
 visible = false
-light_mask = 524288
-visibility_layer = 524288
-position = Vector2(8, 2.38419e-07)
+light_mask = 262144
+visibility_layer = 262144
 scale = Vector2(1.1, 1.1)
-
-[node name="Background" type="Sprite2D" parent="Sprites/SideA"]
-light_mask = 524288
-visibility_layer = 524288
-position = Vector2(-102, 91)
-scale = Vector2(0.6875, 0.697266)
-texture = ExtResource("4_prap6")
 
 [node name="Fuel" type="Sprite2D" parent="Sprites/SideA"]
 light_mask = 524288
 visibility_layer = 524288
-position = Vector2(-225.455, 144.545)
-scale = Vector2(0.4, 0.4)
-texture = ExtResource("5_6emyt")
+position = Vector2(-205, -95)
+scale = Vector2(0.5, 0.5)
+texture = ExtResource("10_2suj0")
 
 [node name="Label" type="Label" parent="Sprites/SideA/Fuel"]
 light_mask = 524288
 visibility_layer = 524288
-offset_left = -75.0
-offset_top = -77.5
-offset_right = 65.0
-offset_bottom = 93.5
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_outline_color = Color(1, 1, 1, 1)
-theme_override_constants/outline_size = 20
-theme_override_fonts/font = ExtResource("6_j52hp")
-theme_override_font_sizes/font_size = 140
-text = "5"
-horizontal_alignment = 1
-vertical_alignment = 1
-metadata/_edit_use_anchors_ = true
-
-[node name="Description" type="RichTextLabel" parent="Sprites/SideA"]
-light_mask = 524288
-visibility_layer = 524288
-offset_left = -184.0
-offset_top = 8.0
-offset_right = -17.0
-offset_bottom = 175.0
-theme_override_colors/default_color = Color(0, 0, 0, 1)
-theme_override_fonts/normal_font = SubResource("FontVariation_xan1t")
-theme_override_font_sizes/normal_font_size = 16
-text = "Example Text Dupa Dupa Dupa"
-metadata/_edit_use_anchors_ = true
-
-[node name="MoveType" type="Sprite2D" parent="Sprites/SideA"]
-position = Vector2(-228.182, 70)
-scale = Vector2(0.4, 0.4)
-texture = ExtResource("7_4djja")
-metadata/_edit_use_anchors_ = true
-
-[node name="Label" type="Label" parent="Sprites/SideA/MoveType"]
-light_mask = 524288
-visibility_layer = 524288
-anchors_preset = -1
-anchor_left = 0.207031
-anchor_top = 0.154652
-anchor_right = 0.753906
-anchor_bottom = 0.822621
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
 offset_left = -128.0
 offset_top = -128.0
 offset_right = -128.0
 offset_bottom = -128.0
+grow_horizontal = 2
+grow_vertical = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_colors/font_outline_color = Color(1, 1, 1, 1)
 theme_override_constants/outline_size = 20
-theme_override_fonts/font = ExtResource("6_j52hp")
+theme_override_fonts/font = ExtResource("11_i25h6")
 theme_override_font_sizes/font_size = 140
 text = "5"
 horizontal_alignment = 1
 vertical_alignment = 1
-metadata/_edit_use_anchors_ = true
-
-[node name="AttackTargets" type="Sprite2D" parent="Sprites/SideA"]
-position = Vector2(-123.636, 149.091)
-scale = Vector2(0.8, 0.8)
-texture = ExtResource("8_y3dw0")
-metadata/_edit_use_anchors_ = true
 
 [node name="Icon1" type="Sprite2D" parent="Sprites/SideA"]
+light_mask = 524288
+visibility_layer = 524288
 position = Vector2(-205, 0)
 scale = Vector2(0.5, 0.5)
-texture = ExtResource("18_74lal")
+texture = ExtResource("12_74lal")
 
 [node name="Label" type="Label" parent="Sprites/SideA/Icon1"]
 light_mask = 524288
@@ -330,16 +603,18 @@ grow_vertical = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_colors/font_outline_color = Color(1, 1, 1, 1)
 theme_override_constants/outline_size = 20
-theme_override_fonts/font = ExtResource("6_j52hp")
+theme_override_fonts/font = ExtResource("11_i25h6")
 theme_override_font_sizes/font_size = 140
 text = "5"
 horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="Icon2" type="Sprite2D" parent="Sprites/SideA"]
+light_mask = 524288
+visibility_layer = 524288
 position = Vector2(-205, 100)
 scale = Vector2(0.5, 0.5)
-texture = ExtResource("19_u2054")
+texture = ExtResource("13_u2054")
 
 [node name="Label" type="Label" parent="Sprites/SideA/Icon2"]
 light_mask = 524288
@@ -356,179 +631,45 @@ grow_vertical = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_colors/font_outline_color = Color(1, 1, 1, 1)
 theme_override_constants/outline_size = 20
-theme_override_fonts/font = ExtResource("6_j52hp")
+theme_override_fonts/font = ExtResource("11_i25h6")
 theme_override_font_sizes/font_size = 140
 text = "5"
 horizontal_alignment = 1
 vertical_alignment = 1
+
+[node name="AfterPlay" type="Sprite2D" parent="Sprites/SideA"]
+light_mask = 524288
+visibility_layer = 524288
+position = Vector2(181.818, 98.1818)
+scale = Vector2(0.75, 0.75)
+texture = ExtResource("14_ocsrf")
+metadata/_edit_use_anchors_ = true
 
 [node name="Actions" type="Sprite2D" parent="Sprites/SideA"]
 position = Vector2(0, 50)
-texture = ExtResource("21_k86ah")
-
-[node name="AfterPlay" type="Sprite2D" parent="Sprites/SideA"]
-position = Vector2(-35, 150)
-scale = Vector2(0.4, 0.4)
-texture = ExtResource("9_goh0x")
-metadata/_edit_use_anchors_ = true
-
-[node name="SideB" type="Node2D" parent="Sprites"]
-visible = false
-modulate = Color(1, 1, 1, 0.491)
-light_mask = 524288
-visibility_layer = 524288
-position = Vector2(-8, 0)
-scale = Vector2(0.8, 0.8)
-
-[node name="Background" type="Sprite2D" parent="Sprites/SideB"]
-light_mask = 524288
-visibility_layer = 524288
-position = Vector2(102, 91)
-scale = Vector2(0.6875, 0.697266)
-texture = ExtResource("4_prap6")
-
-[node name="Description" type="RichTextLabel" parent="Sprites/SideB"]
-light_mask = 524288
-visibility_layer = 524288
-offset_left = 18.75
-offset_top = 8.75
-offset_right = 185.75
-offset_bottom = 175.75
-theme_override_colors/default_color = Color(0, 0, 0, 1)
-theme_override_fonts/normal_font = SubResource("FontVariation_xan1t")
-theme_override_font_sizes/normal_font_size = 16
-text = "Example Text Cycki Cycki Cycki"
-metadata/_edit_use_anchors_ = true
-
-[node name="Fuel" type="Sprite2D" parent="Sprites/SideB"]
-light_mask = 524288
-visibility_layer = 524288
-position = Vector2(224.545, 148.182)
-scale = Vector2(0.4, 0.4)
-texture = ExtResource("5_6emyt")
-
-[node name="Label" type="Label" parent="Sprites/SideB/Fuel"]
-light_mask = 524288
-visibility_layer = 524288
-offset_left = -75.0
-offset_top = -77.5
-offset_right = 65.0
-offset_bottom = 93.5
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_outline_color = Color(1, 1, 1, 1)
-theme_override_constants/outline_size = 20
-theme_override_fonts/font = ExtResource("6_j52hp")
-theme_override_font_sizes/font_size = 140
-text = "5"
-horizontal_alignment = 1
-vertical_alignment = 1
-metadata/_edit_use_anchors_ = true
-
-[node name="MoveType" type="Sprite2D" parent="Sprites/SideB"]
-position = Vector2(225.455, 76.1364)
-scale = Vector2(0.4, 0.4)
-texture = ExtResource("7_4djja")
-metadata/_edit_use_anchors_ = true
-
-[node name="Label" type="Label" parent="Sprites/SideB/MoveType"]
-light_mask = 524288
-visibility_layer = 524288
-anchors_preset = -1
-anchor_left = 0.207031
-anchor_top = 0.154652
-anchor_right = 0.753906
-anchor_bottom = 0.822621
-offset_left = -128.0
-offset_top = -128.0
-offset_right = -128.0
-offset_bottom = -128.0
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_outline_color = Color(1, 1, 1, 1)
-theme_override_constants/outline_size = 20
-theme_override_fonts/font = ExtResource("6_j52hp")
-theme_override_font_sizes/font_size = 140
-text = "5"
-horizontal_alignment = 1
-vertical_alignment = 1
-metadata/_edit_use_anchors_ = true
-
-[node name="AttackTargets" type="Sprite2D" parent="Sprites/SideB"]
-position = Vector2(83.75, 148.75)
-scale = Vector2(0.8, 0.8)
-texture = ExtResource("8_y3dw0")
-metadata/_edit_use_anchors_ = true
-
-[node name="AfterPlay" type="Sprite2D" parent="Sprites/SideB"]
-position = Vector2(170, 150)
-scale = Vector2(0.4, 0.4)
-texture = ExtResource("10_5jphp")
-metadata/_edit_use_anchors_ = true
-
-[node name="Front" type="Node2D" parent="Sprites"]
-visible = false
-position = Vector2(0, 20)
-scale = Vector2(1, 1e-05)
-
-[node name="Label" type="Sprite2D" parent="Sprites/Front"]
-texture = ExtResource("11_dnua6")
-
-[node name="Frame" type="Sprite2D" parent="Sprites/Front"]
-texture = ExtResource("12_c1rf7")
-
-[node name="Gears" type="Sprite2D" parent="Sprites/Front"]
-scale = Vector2(-1, 1)
-texture = ExtResource("13_1vaqd")
-
-[node name="CassetteName" type="Label" parent="Sprites/Front"]
-offset_left = -139.0
-offset_top = -124.0
-offset_right = 146.0
-offset_bottom = -51.9999
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_fonts/font = ExtResource("14_w2qko")
-theme_override_font_sizes/font_size = 26
-text = "SUPA DORIFTO"
-horizontal_alignment = 1
-vertical_alignment = 1
-metadata/_edit_use_anchors_ = true
-
-[node name="ASideLogo" type="Sprite2D" parent="Sprites/Front"]
-light_mask = 524288
-visibility_layer = 524288
-position = Vector2(-154, -40)
-scale = Vector2(0.5, 0.5)
-texture = ExtResource("15_ck6wr")
-
-[node name="BSideLogo" type="Sprite2D" parent="Sprites/Front"]
-light_mask = 524288
-visibility_layer = 524288
-position = Vector2(153, -42)
-scale = Vector2(0.3, 0.3)
-texture = ExtResource("16_eplrv")
-
-[node name="Side" type="Node2D" parent="Sprites"]
-visible = false
-position = Vector2(223, 3)
-scale = Vector2(1e-05, 1)
-
-[node name="Frame" type="Sprite2D" parent="Sprites/Side"]
-texture = ExtResource("17_xsyxj")
+texture = ExtResource("15_k86ah")
 
 [node name="FlipTooltip" type="Sprite2D" parent="."]
 visible = false
-
-[node name="Area2D" type="Area2D" parent="."]
-collision_layer = 8388608
-collision_mask = 8388608
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("RectangleShape2D_0x1d7")
-disabled = true
+position = Vector2(-390, -95)
+scale = Vector2(0.6, 0.6)
+texture = ExtResource("16_bm5ih")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {
 &"": SubResource("AnimationLibrary_o46m7")
 }
+
+[node name="Area2D" type="Area2D" parent="."]
+visible = false
+scale = Vector2(1, 0.15)
+priority = 1
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+position = Vector2(0, -640)
+shape = SubResource("RectangleShape2D_axh4p")
+one_way_collision_margin = 3.0
+disabled = true
 
 [connection signal="mouse_entered" from="Area2D" to="." method="_on_area_2d_mouse_entered"]
 [connection signal="mouse_exited" from="Area2D" to="." method="_on_area_2d_mouse_exited"]

--- a/Features/FightScene/enemy.gd
+++ b/Features/FightScene/enemy.gd
@@ -67,7 +67,7 @@ func create_cassette(cassette_name):
 	new_cassette.side_b_data = Database.cassettes["cassettes"][cassette_name]["side_b"]
 	new_cassette.cassette_name = cassette_name
 	new_cassette.current_side = "A"
-	new_cassette.whose_cassette = GlobalEnums.PLAYER
+       new_cassette.whose_cassette = GlobalEnums.ENEMY
 	cassette_manager.connect_cassette_signals(new_cassette)
 	new_cassette.state = new_cassette.STATE.IN_HAND
 	return new_cassette


### PR DESCRIPTION
## Summary
- sync enemy cassette scene structure with `cassette_v2`
- disable enemy cassette interactions via its collision shape
- mark enemy cassettes as belonging to the enemy

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684add8c8d408320b92775c8aa20e469