### PR TITLE
Refactor cassette side handling

### DIFF
--- a/Features/DeckBuilder/deck.gd
+++ b/Features/DeckBuilder/deck.gd
@@ -60,7 +60,7 @@ func create_cassette(cassette_name):
 	new_cassette.side_a_data = cassette_data[1]
 	new_cassette.side_b_data = cassette_data[2]
 	new_cassette.cassette_name = cassette_data[0]
-	new_cassette.current_side = "A"
+	new_cassette.current_side = Cassette.Side.A
 	new_cassette.update_elements()
 	new_cassette.whose_cassette = GlobalEnums.Player
 	new_cassette.get_node("Node2D/Area2D").visible = false

--- a/Features/FightScene/CassetteSlot/cassette_slot.gd
+++ b/Features/FightScene/CassetteSlot/cassette_slot.gd
@@ -14,7 +14,10 @@ func update_elements() -> void:
 	$Fuel_Amount.modulate = ACTIVE_COLOR if cassette_in_slot!=null else INACTIVE_COLOR
 	$Fuel_Amount.text     = str(cassette_in_slot.get_current_side_fuel()) if cassette_in_slot!=null  else ""
 	$Side.modulate        = ACTIVE_COLOR if cassette_in_slot!=null else INACTIVE_COLOR
-	$Side.text            = cassette_in_slot.current_side if cassette_in_slot!=null else ""
+	var side_text = ""
+	if cassette_in_slot != null:
+		side_text = "A" if cassette_in_slot.current_side == Cassette.Side.A else "B"
+	$Side.text = side_text
 
 func set_cover_state(closed):
 	if closed and cassette_in_slot == null:

--- a/Features/FightScene/cassette_manager.gd
+++ b/Features/FightScene/cassette_manager.gd
@@ -16,16 +16,16 @@ const SLOT_POSITIONS = [
 						Vector2(1179,965),
 						Vector2(1177,920)]
 const CASSETTE_SCALES_IN_SLOTS = [
-								  Vector2(0.79,0.79),
-								  Vector2(0.78,0.78),
-								  Vector2(0.77,0.77),
-								  Vector2(0.76,0.76),
-								  Vector2(0.75,0.75),
-								  Vector2(0.79,0.79),
-								  Vector2(0.78,0.78),
-								  Vector2(0.77,0.77),
-								  Vector2(0.76,0.76),
-								  Vector2(0.75,0.75)]
+									Vector2(0.79,0.79),
+									Vector2(0.78,0.78),
+									Vector2(0.77,0.77),
+									Vector2(0.76,0.76),
+									Vector2(0.75,0.75),
+									Vector2(0.79,0.79),
+									Vector2(0.78,0.78),
+									Vector2(0.77,0.77),
+									Vector2(0.76,0.76),
+									Vector2(0.75,0.75)]
 var screen_size
 var cassette_being_dragged: Cassette
 var is_hovering_on_cassette
@@ -144,12 +144,12 @@ func on_left_click_released():
 
 
 func switch_sides(cassette):
-	if cassette.current_side == "A":
-		cassette.current_side = "B"
-		cassette.switch_sides("B")
+	if cassette.current_side == Cassette.Side.A:
+		cassette.current_side = Cassette.Side.B
+		cassette.switch_sides(Cassette.Side.B)
 	else:
-		cassette.current_side = "A"
-		cassette.switch_sides("A")
+		cassette.current_side = Cassette.Side.A
+		cassette.switch_sides(Cassette.Side.A)
 
 
 func check_if_commit_sequence_button_should_be_activated():

--- a/Features/FightScene/enemy.gd
+++ b/Features/FightScene/enemy.gd
@@ -66,7 +66,7 @@ func create_cassette(cassette_name):
 	new_cassette.side_a_data = Database.cassettes["cassettes"][cassette_name]["side_a"]
 	new_cassette.side_b_data = Database.cassettes["cassettes"][cassette_name]["side_b"]
 	new_cassette.cassette_name = cassette_name
-	new_cassette.current_side = "A"
+	new_cassette.current_side = Cassette.Side.A
 	new_cassette.whose_cassette = GlobalEnums.PLAYER
 	cassette_manager.connect_cassette_signals(new_cassette)
 	new_cassette.state = new_cassette.STATE.IN_HAND
@@ -81,9 +81,9 @@ func select_cassettes_for_sequence():
 		var selected_cassette = hand[selected_cassette_index]
 		var side = rng.randi_range(0,1)
 		if side == 0:
-			selected_cassette.current_side = "A"
+			selected_cassette.current_side = Cassette.Side.A
 		else:
-			selected_cassette.current_side = "B"
+			selected_cassette.current_side = Cassette.Side.B
 		var current_slot = sequence.get_children()[i]
 		remove_cassette_from_hand(selected_cassette)
 		current_slot.add_child(selected_cassette)

--- a/Features/FightScene/enemy_deck.gd
+++ b/Features/FightScene/enemy_deck.gd
@@ -31,7 +31,7 @@ func create_cassette(cassette_name):
 	new_cassette.side_a_data = cassette_data[1]
 	new_cassette.side_b_data = cassette_data[2]
 	new_cassette.cassette_name = cassette_data[0]
-	new_cassette.current_side = "A"
+	new_cassette.current_side = Cassette.Side.A
 	new_cassette.whose_cassette = GlobalEnums.ENEMY
 	cassette_manager.connect_cassette_signals(new_cassette)
 	deck_cassettes.append(new_cassette)

--- a/Features/FightScene/player.gd
+++ b/Features/FightScene/player.gd
@@ -39,7 +39,7 @@ func create_cassette(cassette_name):
 			new_cassette.side_a_actions_path = cassette_info["image_a"]
 			new_cassette.side_b_actions_path = cassette_info["image_b"]
 	new_cassette.cassette_name = cassette_name
-	new_cassette.current_side = "A"
+	new_cassette.current_side = Cassette.Side.A
 	new_cassette.whose_cassette = GlobalEnums.PLAYER
 	cassette_manager.connect_cassette_signals(new_cassette)
 	return new_cassette


### PR DESCRIPTION
## Summary
- Introduce `Side` enum and helper functions in `cassette.gd` to centralize side-specific data
- Simplify side switching by calling `update_actions_texture` and removing repeated path checks
- Update game scripts to use the new enum and display side labels appropriately
- Normalize tab-based indentation across affected scripts

## Testing
- `godot --headless --version` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6896703c4a788320886c1cb6085512a9